### PR TITLE
Updates, corrections, and move "Private/Public entries under SMPTE control"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: Build SMPTE document
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  release:
+    types: [published]
 
 env:
   AWS_REGION: us-east-1
@@ -11,7 +15,12 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'pull_request'
+    if: >
+      github.repository_owner	== 'SMPTE' && (
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      || github.event_name == 'pull_request'
+      || github.event_name == 'release'
+      )
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write
@@ -24,14 +33,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
           submodules: true
 
       - name: Set repository name
         run: echo "REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
 
       - name: Check out all branches with the exception of the current branch
-        run: CUR_BRANCH=$(git rev-parse --abbrev-ref HEAD); for i in `git branch -a | grep remote | grep -v HEAD | grep -v ${CUR_BRANCH}`; do git branch --track ${i#remotes/origin/} $i; done
+        run: CUR_BRANCH=$(git rev-parse --abbrev-ref HEAD); for i in `git branch -a | grep remote | grep -v "remotes/pull" | grep -v HEAD | grep -v ${CUR_BRANCH}`; do git branch --track ${i#remotes/origin/} $i; done
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
@@ -44,7 +52,7 @@ jobs:
         if: github.repository != 'SMPTE/html-pub'
         with:
           AWS_S3_REGION: ${{env.AWS_REGION}}
-          AWS_S3_BUCKET:  ${{env.AWS_S3_BUCKET}}
+          AWS_S3_BUCKET: 	${{env.AWS_S3_BUCKET}}
           AWS_S3_KEY_PREFIX: "${{env.REPOSITORY_NAME}}/"
           CANONICAL_LINK_PREFIX: ${{env.CANONICAL_LINK_PREFIX}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
@@ -54,7 +62,7 @@ jobs:
         if: github.repository == 'SMPTE/html-pub'
         with:
           AWS_S3_REGION: ${{env.AWS_REGION}}
-          AWS_S3_BUCKET:  ${{env.AWS_S3_BUCKET}}
+          AWS_S3_BUCKET: 	${{env.AWS_S3_BUCKET}}
           AWS_S3_KEY_PREFIX: "${{env.REPOSITORY_NAME}}/"
           CANONICAL_LINK_PREFIX: ${{env.CANONICAL_LINK_PREFIX}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 _This repository is *public*._
 
-* [Latest version](https://doc.smpte-doc.org/ag-18/main/)
-* [Redline against the latest edition](https://doc.smpte-doc.org/ag-18/main/pub-rl.html)
+* [Latest draft version](https://doc.smpte-doc.org/ag-18/main/)
+* Latest published version available from the [SMPTE website](https://www.smpte.org/2020-standard-policies-and-governance)
+* [Redline (diff) of the latest draft version against the latest published version](https://doc.smpte-doc.org/ag-18/main/pub-rl.html)
 
 Please consult [CONTRIBUTING.md](./CONTRIBUTING.md), [CONFIDENTIALITY.md](./CONFIDENTIALITY.md), [LICENSE.md](./LICENSE.md) and
 [PATENTS.md](./PATENTS.md) for important notices.

--- a/doc/main.html
+++ b/doc/main.html
@@ -8,9 +8,9 @@
     <script type="module" src="../tooling/smpte.js"></script>
     <meta itemprop="pubType" content="AG" />
     <meta itemprop="pubNumber" content="18" />
-    <meta itemprop="pubState" content="draft" />
-    <meta itemprop="pubDateTime" content="2025-02-27" />
-    <!-- update text for title element as needed -->
+    <meta itemprop="pubState" content="pub" />
+    <meta itemprop="pubStage" content="PUB">
+    <meta itemprop="pubDateTime" content="2025-03-25" />
     <title>Metadata Registers Procedures</title>
     <!-- End of editable section in header-->
   </head>

--- a/doc/main.html
+++ b/doc/main.html
@@ -48,7 +48,7 @@
         </li>
         <li><cite id="bib-smpte-standards-operations-manual">SMPTE Standards Operations Manual</cite>, v3.1
         <a>https://www.smpte.org/about/policies-and-governance</a></li>
-        <li><cite id="bib-smpte-ag-03">SMPTE AG-03</cite>, Permitted Normative References
+        <li><cite id="bib-smpte-ag-03">SMPTE AG 03</cite>, Permitted Normative References
         <a>https://www.smpte.org/about/policies-and-governance</a></li>
       </ul>
 
@@ -882,7 +882,7 @@ REGISTER := "groups" / "elements" / "labels" / "types" / "essence"
 
   <section id="sec-bibliography">
     <ul>
-      <li><cite id="bib-smpte-ag-02">SMPTE AG-02</cite>, Document Naming and Packaging
+      <li><cite id="bib-smpte-ag-02">SMPTE AG 02</cite>, Document Naming and Packaging
         <a>https://www.smpte.org/about/policies-and-governance</a>
       </li>
       <li><cite id="bib-smpte-st-335">SMPTE ST 335</cite>, Metadata Element Dictionary Structure

--- a/doc/main.html
+++ b/doc/main.html
@@ -20,14 +20,14 @@
     <section id="sec-introduction" class="unnumbered">
       <h2>Introduction</h2>
       <p>
-        This section is entirely informative and does not form an integral part of this Administrative Guideline.
+        This clause is entirely informative and does not form an integral part of this Administrative Guideline.
       </p>
       <p>
         This Administrative Guideline covers all classes of <a>Entry</a>(ies) defined across all <a>Metadata Register Structure Document</a>s specified by SMPTE, and specifies:
       </p>
       <ul>
         <li>in <a href="#sec-management-publication"></a>, the process for allocating top-level Class 13 and 14 <a>Node</a>s to external entities;</li>
-        <li>in <a href="#sec-development-publication"></a>, the process of developing and publishing <a>Metadata Register</a>s, which follows the development process specified in the <a href="#bib-smpte-standards-operation-manual"></a>;</li>
+        <li>in <a href="#sec-development-publication"></a>, the process of developing and publishing <a>Metadata Register</a>s, which follows the development process specified in the <a href="#bib-smpte-standards-operations-manual"></a>;</li>
         <li>in <a href="#sec-submission-process"></a>, a process for preparing stable <a>Entry</a>(ies) for inclusion in a <a>Metadata Register</a>; and</li>
         <li>in <a href="#sec-acceptance-criteria"></a>, the criteria for accepting <a>Entry</a>(ies) in <a>Metadata Register</a>s.</li>
       </ul>
@@ -40,29 +40,14 @@
     <section id="sec-normative-references">
 
       <ul>
-        <li><cite id="bib-smpte-st-2003">SMPTE ST 2003</cite>, Types Dictionary Structure
-          <a>https://doi.org/10.5594/SMPTE.ST2003.2012</a>
-        </li>
-        <li><cite id="bib-smpte-st-335">SMPTE ST 335</cite>:2012, Metadata Element Dictionary Structure
-          <a>https://doi.org/10.5594/SMPTE.ST335.2012Am1.2019</a>
-        </li>
-        <li><cite id="bib-smpte-st-335-am1">SMPTE ST 335 Am1</cite>:2019, Metadata Element Dictionary Structure
-          <a>https://doi.org/10.5594/SMPTE.ST335.2012Am1.2019</a>
-        </li>
-        <li><cite id="bib-smpte-st-395">SMPTE ST 395</cite>, Metadata Groups Register
-          <a>https://doi.org/10.5594/SMPTE.ST395.2012</a>
-        </li>
-        <li><cite id="bib-smpte-st-400">SMPTE ST 400</cite>, SMPTE docLabels Structure
-          <a>https://doi.org/10.5594/SMPTE.ST400.2012</a>
-        </li>
-        <li><cite id="bib-smpte-st-298">SMPTE ST 298</cite>, Universal docLabels for Unique Identification of Digital Data
+        <li><cite id="bib-smpte-st-298">SMPTE ST 298</cite>, Universal Labels for Unique Identification of Digital Data
           <a>https://doi.org/10.5594/SMPTE.ST298.2009</a>
         </li>
         <li><cite id="bib-smpte-st-336">SMPTE ST 336</cite>, Data Encoding Protocol Using Key-Length-Value
           <a>https://doi.org/10.5594/SMPTE.ST336.2017</a>
         </li>
-        <li><cite id="bib-smpte-standards-operation-manual">SMPTE Standards Operation Manual</cite>, v3.1
-        <a>https://f.hubspotusercontent00.net/hubfs/5253154/SMPTE%20Standards%20OM%20v3.1.pdf</a></li>
+        <li><cite id="bib-smpte-standards-operations-manual">SMPTE Standards Operations Manual</cite>, v3.1
+        <a>https://www.smpte.org/about/policies-and-governance</a></li>
         <li><cite id="bib-smpte-ag-03">SMPTE AG-03</cite>, Permitted Normative References
         <a>https://www.smpte.org/about/policies-and-governance</a></li>
       </ul>
@@ -80,6 +65,7 @@
           <dd class="note">A more detailed definition is provided in each <a>Metadata Register Structure Document</a>.</dd>
         <dt><dfn>Entry</dfn></dt>
           <dd>Combines one <a>UL</a> and multiple associated properties.</dd>
+          <dd class="note">A more detailed definition is provided in each <a>Metadata Register Structure Document</a>.</dd>
         <dt><dfn>Defining Document</dfn></dt>
           <dd>Document referenced in the <code>Defining Document</code> property of an <a>Entry</a>.</dd>
           <dd class="note">A more detailed definition is provided in each <a>Metadata Register Structure Document</a>.</dd>
@@ -100,9 +86,9 @@
       <h2>General</h2>
 
       <section id="sec-rel-operations-manual">
-        <h3>Relationship with the Standards Operation Manual</h3>
+        <h3>Relationship with the <a href="#bib-smpte-standards-operations-manual"></a></h3>
         <p>
-          This Administrative Guideline expands on the <a href="#bib-smpte-standards-operation-manual"></a>, Section 5.2.5 as applied to Registers. In case of conflict with the <a href="#bib-smpte-standards-operation-manual"></a> and this document, the former prevails.
+          This Administrative Guideline expands on the <a href="#bib-smpte-standards-operations-manual"></a>, Subclause 5.2.5 as applied to Registers. In case of conflict with the <a href="#bib-smpte-standards-operations-manual"></a> and this document, the former prevails.
         </p>
       </section>
 
@@ -115,29 +101,29 @@
         <table id="table-superseded">
           <caption>Superseded Procedures and Criteria.</caption>
           <tr>
-            <td><a href="#bib-smpte-st-335"></a> and <a href="#bib-smpte-st-335-am1"></a></td>
-            <td>Section 5 and Annex B</td>
+            <td><a href="#bib-smpte-st-335"></a></td>
+            <td>Clause 5 and Annex B</td>
           </tr>
           <tr>
             <td><a href="#bib-smpte-st-395"></a></td>
-            <td>Section 5 and Annex B</td>
+            <td>Clause 5 and Annex B</td>
           </tr>
           <tr>
             <td><a href="#bib-smpte-st-2003"></a></td>
-            <td>Section 5 and Annex B</td>
+            <td>Clause 5 and Annex B</td>
           </tr>
           <tr>
             <td><a href="#bib-smpte-st-400"></a></td>
-            <td>Section 5 and Annex B</td>
+            <td>Clause 5 and Annex B</td>
           </tr>
         </table>
 
       </section>
 
       <section id="sec-register-sub-group">
-        <h3>Metadata Register Sub Group</h3>
+        <h3><a>Metadata Register Sub Group</a></h3>
         <p>
-          The Metadata Register Sub Group is the Sub Group (as defined in the <a href="#bib-smpte-standards-operation-manual"></a>) responsible for developing <a>Release</a>s, as established by TC 30MR.
+          The <dfn>Metadata Register Sub Group</dfn> is the Sub Group (as defined in the <a href="#bib-smpte-standards-operations-manual"></a>) responsible for developing <a>Release</a>s, as established by TC 30MR.
         </p>
       </section>
 
@@ -149,9 +135,9 @@
       </section>
 
       <section id="sec-version-byte">
-        <h3>Current Version Byte</h3>
+        <h3><a>Current Version Byte</a></h3>
         <p>
-          The SMPTE Registration Authority website shall include the current value of the version byte ("Current Version Byte") for each <a>Metadata Register</a>, as determined from time-to-time by TC 30MR.
+          The SMPTE Registration Authority website shall include the current value of the version byte (<dfn>Current Version Byte</dfn>) for each <a>Metadata Register</a>, as determined from time-to-time by TC 30MR.
         </p>
       </section>
     </section>
@@ -160,44 +146,47 @@
       <h2><a>Entry</a> Management and Publication</h2>
 
       <section id="sec-private-use">
-        <h3>Private-Use Entries</h3>
+        <h3><a>Private-Use Entry</a>(ies)</h3>
         <p>
-          A Private-Use Entry is an <a>Entry</a> belonging to a top-level Class 14 <a>Node</a> whose control has been delegated to an entity other than SMPTE according to <a href="#sec-allocation-transfer"></a>
+          A <dfn>Private-Use Entry</dfn> is an <a>Entry</a> belonging to a top-level Class 14 <a>Node</a> whose control has been delegated to an entity other than SMPTE according to <a href="#sec-allocation-transfer"></a>.
         </p>
         <p class="note">
-          The <a>Controlling Organization</a> of a Public-Use Entry can transfer control of the <a>Entry</a> back to SMPTE as specified in <a href="#sec-allocation-transfer"></a>, <a href="#sec-private-use-control"></a> lists <a>Entry</a>(ies) that were previously Private-Use Entries, but are currently SMPTE-Controlled Entries.
+          The <a>Controlling Organization</a> of a <a>Private-Use Entry</a> can transfer control of the <a>Entry</a> back to SMPTE as specified in <a href="#sec-allocation-transfer"></a>. <a href="#sec-private-use-control"></a> lists <a>Entry</a>(ies) that were previously <a>Private-Use Entry</a>(ies), but are currently <a>SMPTE-Controlled Entry</a>(ies).
         </p>
         <p>
-          Private-Use Entries shall not be published by SMPTE. The <a>Controlling Organization</a> of a Private-Use entry is however encouraged to maintain and publish it using a method consistent with those specified herein.
+          <a>Private-Use Entry</a>(ies) shall not be published by SMPTE. The <a>Controlling Organization</a> of a <a>Private-Use Entry</a> is however encouraged to maintain and publish it using a method consistent with those specified herein.
         </p>
         <p>
-          The management and publication of Private-Use Entries is the sole responsibility of the <a>Controlling Organization</a>.
+          The management and publication of <a>Private-Use Entry</a>(ies) is the sole responsibility of the <a>Controlling Organization</a>.
+        </p>
+        <p class="note">
+          Conformance of the <a>UL</a> of <a>Private-Use Entry</a>(ies) remains governed by <a href="#bib-smpte-st-298"></a> and constrained by <a href="#bib-smpte-st-336"></a>.
         </p>
       </section>
 
       <section id="sec-public-use">
-        <h3>Public-Use Entries</h3>
+        <h3><a>Public-Use Entry</a>(ies)</h3>
         <p>
-          A Public-Use Entry is an <a>Entry</a> belonging to a top-level Class 13 <a>Node</a> whose control has been delegated to an entity other than SMPTE according to <a href="#sec-private-use-control"></a>.
+          A <dfn>Public-Use Entry</dfn> is an <a>Entry</a> belonging to a top-level Class 13 <a>Node</a> whose control has been delegated to an entity other than SMPTE according to <a href="#sec-allocation-transfer"></a>.
         </p>
         <p class="note">
-          The <a>Controlling Organization</a> of a Private-Use Entry can transfer control of the <a>Entry</a> back to SMPTE as specified in <a href="#sec-private-use-control"></a>. 0 lists <a>Entry</a>(ies) that were previously Public-Use Entries, but are currently SMPTE-Controlled Entries.
+          The <a>Controlling Organization</a> of a <a>Public-Use Entry</a> can transfer control of the <a>Entry</a> back to SMPTE as specified in <a href="#sec-allocation-transfer"></a>. <a href="#sec-public-use-control"></a> lists <a>Entry</a>(ies) that were previously <a>Public-Use Entry</a>(ies), but are currently <a>SMPTE-Controlled Entry</a>(ies).
         </p>
         <p>
-          Public-Use Entries shall be published by SMPTE using the <a>Release</a> process specified in <a href="#sec-development-publication"></a>.
+          <a>Public-Use Entry</a>(ies) shall be published by SMPTE using the <a>Release</a> process specified in <a href="#sec-development-publication"></a>.
         </p>
         <p>
-          Each <a>Controlling Organization</a> shall submit for publication all Public-Use Entries it defines.
+          Each <a>Controlling Organization</a> shall submit for publication all <a>Public-Use Entry</a>(ies) it defines.
         </p>
       </section>
 
       <section id="sec-smpte-control">
-        <h3>SMPTE-Controlled Entry</h3>
+        <h3><a>SMPTE-Controlled Entry</a></h3>
         <p>
-          A SMPTE-Controlled Entry is an <a>Entry</a> that is neither a Private-Use Entry nor a Public-Use Entry.
+          A <dfn>SMPTE-Controlled Entry</dfn> is an <a>Entry</a> that is neither a <a>Private-Use Entry</a> nor a <a>Public-Use Entry</a>.
         </p>
         <p>
-          SMPTE-Controlled Entries shall be published by SMPTE using the <a>Release</a> process specified in <a href="#sec-development-publication"></a>.
+          <a>SMPTE-Controlled Entry</a>(ies) shall be published by SMPTE using the <a>Release</a> process specified in <a href="#sec-development-publication"></a>.
         </p>
         <p>
           No SMPTE Engineering Document should be balloted to FCD until all <a>Entry</a>(ies) it defines have reached the "mature" state.
@@ -217,7 +206,7 @@
       <section id="sec-dev-general">
         <h3>General</h3>
         <p>
-          A <a>Release</a> follows the development process for Engineering Documents, as specified in the <a href="#bib-smpte-standards-operation-manual"></a>.
+          A <a>Release</a> follows the development process for Engineering Documents, as specified in the <a href="#bib-smpte-standards-operations-manual"></a>.
         </p>
         <p>
           The document number of the <a>Release</a> is assigned as provided in <a href="#bib-smpte-ag-02"></a>.
@@ -230,7 +219,7 @@
       <section id="sec-dev-initiation">
         <h3>Initiation</h3>
         <p>
-          A <a>Release</a> is initiated by creating a Working Draft consisting of all <a>Entry</a>(ies) whose <a>Submission</a> is in the "Accepted" state at the time of initiation.
+          A <a>Release</a> is initiated by creating a Working Draft consisting of all <a>Entry</a>(ies) whose <a>Submission</a> is in the "accepted" state at the time of initiation.
         </p>
         <p class="note">
           As a result, only <a>Entry</a>(ies) that have undergone the <a>Submission</a> process are published.
@@ -251,12 +240,12 @@
       </section>
 
       <section id="sec-dev-project">
-        <h3>Release Project</h3>
+        <h3><a>Release</a> Project</h3>
         <p>
-          There is one Project, as defined in the <a href="#bib-smpte-standards-operation-manual"></a>, for each <a>Release</a>.
+          There is one Project, as defined in the <a href="#bib-smpte-standards-operations-manual"></a>, for each <a>Release</a>.
         </p>
         <p>
-          The Project shall be assigned to the Metadata Register Sub Group.
+          The Project shall be assigned to the <a>Metadata Register Sub Group</a>.
         </p>
         <p>
           To help distinguish between <a>Release</a>s, the Project should be given a distinctive name.
@@ -267,7 +256,7 @@
       </section>
 
       <section id="sec-dev-numbering">
-        <h3>Release Numbering</h3>
+        <h3><a>Release</a> Numbering</h3>
         <p>
           A <a>Release</a> is numbered according to the Document Numbering requirements specified in <a href="#bib-smpte-ag-02"></a>.
         </p>
@@ -300,10 +289,10 @@
       <section id="sec-submission-general">
         <h3>General</h3>
         <p>
-          A <dfn>Submission</dfn> is a request to alter a <a>Metadata Register</a>. It follows the <a>Submission</a> process, which is specified in the following Sections and illustrated in <a href="#figure-submission-process"></a>, and is intended to prepare stable <a>Entry</a>(ies) for inclusion in a <a>Release</a>.
+          A <dfn>Submission</dfn> is a request to alter a <a>Metadata Register</a>. It follows the <a>Submission</a> process, which is specified in the following subclauses and illustrated in <a href="#figure-submission-process"></a>, and is intended to prepare stable <a>Entry</a>(ies) for inclusion in a <a>Release</a>.
         </p>
         <p>
-          <a href="#sec-allocation-transfer"></a> provides selected examples of the <a>Submission</a> process.</p>
+          <a href="#sec-examples"></a> provides selected examples of the <a>Submission</a> process.</p>
 
           <figure id="figure-submission-process">
             <img class="figure" src="media/submission-process.png">
@@ -312,20 +301,20 @@
 
         
         <p>
-          The Metadata Register Sub Group shall make available to its parent Technology Committee all <a>Submission</a>s not incorporated in a <a>Release</a>. The Standards Vice President may, at his or her discretion, make the latter available publicly.
+          The <a>Metadata Register Sub Group</a> shall make available to its parent Technology Committee all <a>Submission</a>s not incorporated in a <a>Release</a>. The Standards Vice President may, at his or her discretion, make the latter available publicly.
         </p>
       </section>
       
       <section id="sec-submission-initiation">
         <h3>Initiation</h3>
         <p>
-          A <a>Submission</a> achieves "initial_draft" state upon submission by a Submitter to the Metadata Register Sub Group.
+          A <a>Submission</a> achieves "initial_draft" state upon submission by a Submitter to the <a>Metadata Register Sub Group</a>.
         </p>
         <p>
           The <a>Submission</a> shall meet the Acceptance Criteria specified in <a href="#sec-acceptance-criteria"></a>.
         </p>
         <p class="note">
-          Submitters are encouraged to work with the chair of the Metadata Register Sub Group prior to initiating a <a>Submission</a> to ensure
+          Submitters are encouraged to work with the chair of the <a>Metadata Register Sub Group</a> prior to initiating a <a>Submission</a> to ensure
           that it meets the Acceptance Criteria. </p>
       </section>
       
@@ -335,10 +324,10 @@
         <section id="sec-initial-actions">
           <h4>Actions</h4>
           <p>
-            The <a>Submission</a> shall be offered for review to the Metadata Register Sub Group.
+            The <a>Submission</a> shall be offered for review to the <a>Metadata Register Sub Group</a>.
           </p>
           <p>
-            The Submitter shall be responsible for addressing any deviation from the Acceptance Criteria noted by the Metadata Register Sub Group, and submitting a revised <a>Submission</a>.
+            The Submitter shall be responsible for addressing any deviation from the Acceptance Criteria noted by the <a>Metadata Register Sub Group</a>, and submitting a revised <a>Submission</a>.
           </p>
           <p class="note">
             An "initial_draft" <a>Submission</a> is susceptible to significant substantive changes.
@@ -355,7 +344,7 @@
               every <a>UL</a> defined by the <a>Submission</a> has been reserved such that it is not available to any other <a>Submission</a>; and
             </li>
             <li>
-              the Metadata Register Sub Group has not determined, by consensus, that the <a>Submission</a> fails to meet the Acceptance Criteria.
+              the <a>Metadata Register Sub Group</a> has not determined, by consensus, that the <a>Submission</a> fails to meet the Acceptance Criteria.
             </li>
           </ul>
         </section>
@@ -370,7 +359,7 @@
               requested by the Submitter; or
             </li>
             <li>
-              the <a>Submission</a> has been abandoned, as determined by consensus of the Technology Committee of the Metadata Register Sub Group.
+              the <a>Submission</a> has been abandoned, as determined by consensus of the Technology Committee of the <a>Metadata Register Sub Group</a>.
             </li>
           </ul>
         </section>
@@ -382,23 +371,23 @@
         <section id="sec-draft-actions">
           <h4>Actions</h4>
           <p>
-            The <a>Submission</a> shall be offered to the parent Technology Committee of the Metadata Register Sub Group for review.
+            The <a>Submission</a> shall be offered to the parent Technology Committee of the <a>Metadata Register Sub Group</a> for review.
           </p>
           <p class="note">
             A "draft" <a>Submission</a> remains susceptible to modifications following TC review.
           </p>
           <p class="note">
-            The Technology Committee Chair determines the duration of the review, as needed to achieve the transition criteria of <a href="#sec-draft-to-mature"></a> This duration can be arbitrarily short if, for instance, the <a>Submission</a> was previously reviewed and changes are trivial.
+            The Technology Committee Chair determines the duration of the review, as needed to achieve the transition criteria of <a href="#sec-draft-to-mature"></a>. This duration can be arbitrarily short if, for instance, the <a>Submission</a> was previously reviewed and changes are trivial.
           </p>
         </section>
 
         <section id="sec-draft-to-mature">
           <h4>Transition to mature State</h4>
           <p>
-            The <a>Submission</a> shall transition to the "mature" state unless the parent Technology Committee of the Metadata Register Sub Group has determined, by consensus, that the <a>Submission</a> fails to meet the Acceptance Criteria.
+            The <a>Submission</a> shall transition to the "mature" state unless the parent Technology Committee of the <a>Metadata Register Sub Group</a> has determined, by consensus, that the <a>Submission</a> fails to meet the Acceptance Criteria.
           </p>
           <p class="note">
-            Members that wish to provide comments beyond those related to the Acceptance Criteria are encouraged to join the group responsible for the <a>Submission</a> .
+            Members that wish to provide comments beyond those related to the Acceptance Criteria are encouraged to join the group responsible for the <a>Submission</a>.
           </p>
         </section>
 
@@ -419,7 +408,7 @@
               requested by the Submitter; or
             </li>
             <li>
-              the <a>Submission</a> has been abandoned, as determined by consensus of the Technology Committee of the Metadata Register Sub Group.
+              the <a>Submission</a> has been abandoned, as determined by consensus of the Technology Committee of the <a>Metadata Register Sub Group</a>.
             </li>
           </ul>
         </section>
@@ -461,7 +450,7 @@
               requested by the Submitter; or
             </li>
             <li>
-              the <a>Submission</a> has been abandoned, as determined by consensus of the parent Technology Committee of the Metadata Register Sub Group.
+              the <a>Submission</a> has been abandoned, as determined by consensus of the parent Technology Committee of the <a>Metadata Register Sub Group</a>.
             </li>
           </ul>
         </section>
@@ -499,13 +488,13 @@
       <section id="sec-acceptance-general">
         <h3>General</h3>
         <p>
-          <a>Submission</a>s defining Public-Use Entries shall meet the criteria of <a href="#sec-acceptance-common"></a> and <a href="#sec-acceptance-public"></a>.
+          <a>Submission</a>s defining <a>Public-Use Entry</a>(ies) shall meet the criteria of <a href="#sec-acceptance-common"></a> and <a href="#sec-acceptance-public"></a>.
         </p>
         <p>
           <a>Submission</a>s defining top-level Class 13 or Class 14 <a>Node</a>s shall meet the criteria of <a href="#sec-acceptance-common"></a> and <a href="#sec-acceptance-top"></a>.
         </p>
         <p>
-          <a>Submission</a>s defining SMPTE-Controlled Entries other than top-level Class 13 or Class 14 <a>Node</a>s shall meet the criteria of <a href="#sec-acceptance-common"></a> and <a href="#sec-acceptance-smpte"></a>.
+          <a>Submission</a>s defining <a>SMPTE-Controlled Entry</a>(ies) other than top-level Class 13 or Class 14 <a>Node</a>s shall meet the criteria of <a href="#sec-acceptance-common"></a> and <a href="#sec-acceptance-smpte"></a>.
         </p>
       </section>
 
@@ -522,7 +511,7 @@
         <section id="sec-filename">
           <h4><a>Submission</a> File Name</h4>
           <p>
-            A submission should consist of a single zip file.
+            A <a>Submission</a> should consist of a single zip file.
           </p>
           <p>
             The filename of the zip file should conform to the following <code>FILENAME</code> syntax
@@ -539,10 +528,10 @@ DD := 2DIGIT
 </pre>
           
           <p>
-            The <code>TC</code> field is the short name of the parent TC of the Metadata Register Sub Group, e.g. 30MR.
+            The <code>TC</code> field is the short name of the parent TC of the <a>Metadata Register Sub Group</a>, e.g. 30MR.
           </p>
           <p>
-            The <code>TYPE</code> field shall be selected based on the nature of the submission as specified in <a href="#table-submission-type"></a>
+            The <code>TYPE</code> field shall be selected based on the nature of the <a>Submission</a> as specified in <a href="#table-submission-type"></a>.
           </p>
 
           <table id="table-submission-type">
@@ -550,7 +539,7 @@ DD := 2DIGIT
             <thead>
               <tr>
                 <th>TYPE</th>
-                <th>Type of submission</th>
+                <th>Type of <a>Submission</a></th>
               </tr>
             </thead>
             <tbody>
@@ -582,7 +571,7 @@ DD := 2DIGIT
           </p>
 
           <p>
-            The <code>DESCRIPTION</code> field shall be selected based on the value of the TYPE field.
+            The <code>DESCRIPTION</code> field shall be selected based on the value of the <code>TYPE</code> field as specified in <a href="#table-submission-description"></a>.
           </p>
 
           <table id="table-submission-description">
@@ -638,12 +627,12 @@ DD := 2DIGIT
             Each XML document shall conform to one of the XML Schema definitions, which shall be determined by TC 30MR from time-to-time and published on the SMPTE Registration Authority website.
           </p>
           <p>
-            The filename of each document should conform to the following DOCNAME syntax:
+            The filename of each document should conform to the following <code>DOCNAME</code> syntax:
           </p>
 
 <pre>
 DOCNAME := TC "-REG-" TYPE "-" DESCRIPTION "-" REGISTER
-REGISTER := "groups" / "elements" / "labels" / "types"
+REGISTER := "groups" / "elements" / "labels" / "types" / "essence"
 </pre>
 
           <p>
@@ -658,12 +647,12 @@ REGISTER := "groups" / "elements" / "labels" / "types"
         </section>
 
         <section id="sec-unique-ul">
-          <h4>Unique UL</h4>
+          <h4>Unique <a>UL</a></h4>
           <p>
             No <a>UL</a> added by the <a>Submission</a> shall be equal to any published or reserved <a>UL</a>.
           </p>
           <p>
-            This equality shall ignore the value of the <code>Version Byte</code> (Byte 8).
+            This equality shall ignore the value of the version byte (byte 8).
           </p>
         </section>
 
@@ -679,7 +668,7 @@ REGISTER := "groups" / "elements" / "labels" / "types"
         <section id="sec-consistency">
           <h4>Consistency</h4>
           <p>
-            Each <a>Entry</a> defined by the <a>Submission</a> should be consistent other <a>Entry</a>(ies) within the same <a>Node</a>.
+            Each <a>Entry</a> defined by the <a>Submission</a> should be consistent with other <a>Entry</a>(ies) within the same <a>Node</a>.
           </p>
         </section>
 
@@ -714,13 +703,13 @@ REGISTER := "groups" / "elements" / "labels" / "types"
         <section id="sec-top-version-byte">
           <h4>Version Byte</h4>
           <p>
-            The Version Byte of each new <a>UL</a> shall be Current Version Byte specified in <a href="#sec-version-byte"></a>.
+            The version byte (byte 8) of each new <a>UL</a> shall be <a>Current Version Byte</a> specified in <a href="#sec-version-byte"></a>.
           </p>
         </section>
       </section>
       
       <section id="sec-acceptance-smpte">
-        <h3>SMPTE-Controlled Entries</h3>
+        <h3><a>SMPTE-Controlled Entry</a>(ies)</h3>
 
         <section id="sec-smpte-submitter">
           <h4>Submitter</h4>
@@ -732,7 +721,7 @@ REGISTER := "groups" / "elements" / "labels" / "types"
         <section id="sec-smpte-version-byte">
           <h4>Version Byte</h4>
           <p>
-            The <code>Version Byte</code> of each new <a>UL</a> shall be Current Version Byte specified in Section <a href="#sec-version-byte"></a>.
+            The version byte (byte 8) of each new <a>UL</a> shall be <a>Current Version Byte</a> specified in <a href="#sec-version-byte"></a>.
           </p>
         </section>
 
@@ -762,7 +751,7 @@ REGISTER := "groups" / "elements" / "labels" / "types"
       </section>
 
       <section id="sec-acceptance-public">
-        <h3>Criteria for Public-Use Entries</h3>
+        <h3>Criteria for <a>Public-Use Entry</a>(ies)</h3>
 
         <section id="sec-public-submitter">
           <h4>Submitter</h4>
@@ -781,7 +770,7 @@ REGISTER := "groups" / "elements" / "labels" / "types"
         <section id="sec-public-version-byte">
           <h4>Version Byte</h4>
           <p>
-            The <code>Version Byte</code> of each new <a>UL</a> added by the <a>Submission</a> is at the discretion of the Submitter.
+            The version byte (byte 8) of each new <a>UL</a> added by the <a>Submission</a> is at the discretion of the Submitter.
           </p>
         </section>
       </section>
@@ -835,7 +824,7 @@ REGISTER := "groups" / "elements" / "labels" / "types"
 
     <section class="annex" id="sec-allocation-transfer">
       <h2>
-        Allocation and Transfer of Control of Public-Use Entries and Private-Use Entries (normative)
+        Allocation and Transfer of Control of <a>Public-Use Entry</a>(ies) and <a>Private-Use Entry</a>(ies) (normative)
       </h2>
 
       <section id="sec-allocation">
@@ -850,7 +839,7 @@ REGISTER := "groups" / "elements" / "labels" / "types"
           Upon receipt of the request and processing fee, the Director of Engineering shall initiate a <a>Submission</a> defining the <a>Node</a> being requested.
         </p>
         <p>
-          When the <a>Submission</a> achieves "draft" status, the entity becomes the <a>Controlling Organization</a> of all <a>Entry</a>(ies) within the <a>Node</a>, excluding the <a>Node</a> <a>Entry</a> itself, across all <a>Metadata Register Structure Document</a>.
+          When the <a>Submission</a> achieves "draft" status, the entity becomes the <a>Controlling Organization</a> of all <a>Entry</a>(ies) within the <a>Node</a>, excluding the <a>Node</a> <a>Entry</a> itself, across all <a>Metadata Register Structure Document</a>s.
         </p>
         <p>
           If the <a>Submission</a> is Withdrawn, the processing fee shall be returned to the requesting party.
@@ -860,7 +849,7 @@ REGISTER := "groups" / "elements" / "labels" / "types"
       <section id="sec-transfer">
         <h3>Transfer of Control</h3>
         <p>
-          The <a>Controlling Organization</a> of a Private-Use or a Public-Use Entry may, at its sole discretion, transfer control of the <a>Entry</a> to SMPTE at perpetuity.
+          The <a>Controlling Organization</a> of a <a>Private-Use Entry</a> or a <a>Public-Use Entry</a> may, at its sole discretion, transfer control of the <a>Entry</a> to SMPTE at perpetuity.
         </p>
         <p>
           The document stipulating the transfer of control shall be in a form determined by the Director of Engineering.
@@ -869,85 +858,48 @@ REGISTER := "groups" / "elements" / "labels" / "types"
     </section>
 
     <section class="annex" id="sec-private-use-control">
-      <h2>Private-Use Entries under SMPTE Control (normative)</h2>
+      <h2><a>Private-Use Entry</a>(ies) under SMPTE Control (normative)</h2>
       <p>
-        <a href="#table-private-use"></a> lists Private-Use Entries whose control has been delegated to SMPTE.
+        The SMPTE Registration Authority website shall include a list of <a>Private-Use Entry</a>(ies) whose control has been delegated to SMPTE.
       </p>
 
-      <table id="table-private-use">
-        <caption>Private-Use Entries Controlled by SMPTE.</caption>
-        <thead>
-          <tr>
-            <th><a>Node</a> <a>UL</a></th>
-            <th><a>Node</a> Name</th>
-            <th>Notes</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td colspan="3">None</td>
-          </tr>
-        </tbody>
-      </table>
-
       <p class="note">
-        A Private-Use Entry Controlled by SMPTE undergoes the same <a>Submission</a> process as any other SMPTE-Controlled Entry, and cannot be deleted and reused (see <a href="#sec-deletion"></a>).
+        A <a>Private-Use Entry</a> Controlled by SMPTE undergoes the same <a>Submission</a> process as any other <a>SMPTE-Controlled Entry</a>, and cannot be deleted and reused (see <a href="#sec-deletion"></a>).
       </p>
 
     </section>
 
     <section class="annex" id="sec-public-use-control">
-      <h2>Public-Use Entries under SMPTE Control (normative)</h2>
+      <h2><a>Public-Use Entry</a>(ies) under SMPTE Control (normative)</h2>
       <p>
-        <a href="#table-public-use"></a> lists Public-Use Entries whose control has been delegated to SMPTE.
+        The SMPTE Registration Authority website shall include a list of <a>Public-Use Entry</a>(ies) whose control has been delegated to SMPTE.
       </p>
-      <table id="table-public-use">
-        <caption>Public-Use Entries Controlled by SMPTE.</caption>
-        <thead>
-          <tr>
-            <th>Bytes 9..11</th>
-            <th><a>Node</a> Name</th>
-            <th>Notes</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>0D.01.01</td>
-            <td>Structural Metadata</td>
-            <td> </td>
-          </tr>
-          <tr>
-            <td>0D.01.02</td>
-            <td>Partition Packs | Operational Patterns</td>
-            <td> </td>
-          </tr>
-          <tr>
-            <td>0D.01.03</td>
-            <td>Essence Containers</td>
-            <td rowspan="2">Delegated by AMWA Association.</td>
-          </tr>
-          <tr>
-            <td>0D.01.04</td>
-            <td>Descriptive Metadata Schemes</td>
-          </tr>
-          <tr>
-            <td>0D.01.05</td>
-            <td>Generic Stream Partition</td>
-            <td> </td>
-          </tr>
-          <tr>
-            <td>0D.01.06</td>
-            <td>Application Metadata Plugin</td>
-            <td> </td>
-          </tr>
-        </tbody>
-      </table>
+
+      <p class="note">
+        A <a>Public-Use Entry</a> Controlled by SMPTE undergoes the same <a>Submission</a> process as any other <a>SMPTE-Controlled Entry</a>, and cannot be deleted and reused (see <a href="#sec-deletion"></a>).
+      </p>
     </section>
 
   <section id="sec-bibliography">
     <ul>
       <li><cite id="bib-smpte-ag-02">SMPTE AG-02</cite>, Document Naming and Packaging
-        <a>https://www.smpte.org/about/policies-and-governance</a></li>
+        <a>https://www.smpte.org/about/policies-and-governance</a>
+      </li>
+      <li><cite id="bib-smpte-st-335">SMPTE ST 335</cite>, Metadata Element Dictionary Structure
+        <a>https://doi.org/10.5594/SMPTE.ST335.2012Am1.2019</a>
+      </li>
+      <li><cite id="bib-smpte-st-395">SMPTE ST 395</cite>, Metadata Groups Register
+        <a>https://doi.org/10.5594/SMPTE.ST395.2014</a>
+      </li>
+      <li><cite id="bib-smpte-st-400">SMPTE ST 400</cite>, SMPTE Labels Structure
+        <a>https://doi.org/10.5594/SMPTE.ST400.2012</a>
+      </li>
+      <li><cite id="bib-smpte-st-2003">SMPTE ST 2003</cite>, Types Dictionary Structure
+        <a>https://doi.org/10.5594/SMPTE.ST2003.2012</a>
+      </li>
+      <li><cite id="bib-smpte-st-2088">SMPTE ST 2088</cite>, Essence Element Key Register Structure
+        <a>https://doi.org/10.5594/SMPTE.ST2088.2019</a>
+      </li>
     </ul>
   </section>
 

--- a/doc/main.html
+++ b/doc/main.html
@@ -883,7 +883,7 @@ REGISTER := "groups" / "elements" / "labels" / "types" / "essence"
   <section id="sec-bibliography">
     <ul>
       <li><cite id="bib-smpte-ag-02">SMPTE AG 02</cite>, Document Naming and Packaging
-        <a>https://doc.smpte-doc.org/ag-02/main/</a></li>
+        <a>https://doc.smpte-doc.org/ag-02/main/</a>
       </li>
       <li><cite id="bib-smpte-st-335">SMPTE ST 335</cite>, Metadata Element Dictionary Structure
         <a>https://pub.smpte.org/doc/st335/</a>

--- a/doc/main.html
+++ b/doc/main.html
@@ -9,7 +9,7 @@
     <meta itemprop="pubType" content="AG" />
     <meta itemprop="pubNumber" content="18" />
     <meta itemprop="pubState" content="draft" />
-    <meta itemprop="pubDateTime" content="2023-04-09" />
+    <meta itemprop="pubDateTime" content="2025-02-27" />
     <!-- update text for title element as needed -->
     <title>Metadata Registers Procedures</title>
     <!-- End of editable section in header-->
@@ -41,16 +41,16 @@
 
       <ul>
         <li><cite id="bib-smpte-st-298">SMPTE ST 298</cite>, Universal Labels for Unique Identification of Digital Data
-          <a>https://doi.org/10.5594/SMPTE.ST298.2009</a>
+          <a>https://pub.smpte.org/pub/st298/</a>
         </li>
         <li><cite id="bib-smpte-st-336">SMPTE ST 336</cite>, Data Encoding Protocol Using Key-Length-Value
-          <a>https://doi.org/10.5594/SMPTE.ST336.2017</a>
+          <a>https://pub.smpte.org/pub/st336/</a>
         </li>
         <li><cite id="bib-smpte-standards-operations-manual">SMPTE Standards Operations Manual</cite>, v3.1
         <a>https://www.smpte.org/about/policies-and-governance</a></li>
         <li><cite id="bib-smpte-ag-03">SMPTE AG 03</cite>, Permitted Normative References
-        <a>https://www.smpte.org/about/policies-and-governance</a></li>
-      </ul>
+          <a>https://doc.smpte-doc.org/ag-03/main/</a></li>
+        </ul>
 
     </section>
 
@@ -883,22 +883,22 @@ REGISTER := "groups" / "elements" / "labels" / "types" / "essence"
   <section id="sec-bibliography">
     <ul>
       <li><cite id="bib-smpte-ag-02">SMPTE AG 02</cite>, Document Naming and Packaging
-        <a>https://www.smpte.org/about/policies-and-governance</a>
+        <a>https://doc.smpte-doc.org/ag-02/main/</a></li>
       </li>
       <li><cite id="bib-smpte-st-335">SMPTE ST 335</cite>, Metadata Element Dictionary Structure
-        <a>https://doi.org/10.5594/SMPTE.ST335.2012Am1.2019</a>
+        <a>https://pub.smpte.org/doc/st335/</a>
       </li>
       <li><cite id="bib-smpte-st-395">SMPTE ST 395</cite>, Metadata Groups Register
-        <a>https://doi.org/10.5594/SMPTE.ST395.2014</a>
+        <a>http://pub.smpte.org/pub/st395/</a>
       </li>
       <li><cite id="bib-smpte-st-400">SMPTE ST 400</cite>, SMPTE Labels Structure
-        <a>https://doi.org/10.5594/SMPTE.ST400.2012</a>
+        <a>https://pub.smpte.org/pub/st400/</a>
       </li>
       <li><cite id="bib-smpte-st-2003">SMPTE ST 2003</cite>, Types Dictionary Structure
-        <a>https://doi.org/10.5594/SMPTE.ST2003.2012</a>
+        <a>https://pub.smpte.org/pub/st2003/</a>
       </li>
       <li><cite id="bib-smpte-st-2088">SMPTE ST 2088</cite>, Essence Element Key Register Structure
-        <a>https://doi.org/10.5594/SMPTE.ST2088.2019</a>
+        <a>https://pub.smpte.org/pub/st2088/</a>
       </li>
     </ul>
   </section>

--- a/doc/main.html
+++ b/doc/main.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <script src="../tooling/smpte.js"></script>
+    <script type="module" src="../tooling/smpte.js"></script>
     <meta itemprop="pubType" content="AG" />
     <meta itemprop="pubNumber" content="18" />
     <meta itemprop="pubState" content="draft" />
@@ -76,21 +76,18 @@
         <dt><dfn>Controlling Organization</dfn></dt>
           <dd>Entity responsible for the creation, modification or deletion of an <a>Entry</a>.</dd>
         <dt><dfn>Node</dfn></dt>
-          <dd><a>Entry</a> that can contain other <a>Entry</a>(ies).
-            <p class="note">A more detailed definition is provided in each <a>Metadata Register Structure Document</a>.</p>
-          </dd>
+          <dd><a>Entry</a> that can contain other <a>Entry</a>(ies).</dd>
+          <dd class="note">A more detailed definition is provided in each <a>Metadata Register Structure Document</a>.</dd>
         <dt><dfn>Entry</dfn></dt>
           <dd>Combines one <a>UL</a> and multiple associated properties.</dd>
         <dt><dfn>Defining Document</dfn></dt>
-          <dd>Document referenced in the <code>Defining Document</code> property of an <a>Entry</a>.
-            <p class="note">A more detailed definition is provided in each <a>Metadata Register Structure Document</a>.</p>
-          </dd>
+          <dd>Document referenced in the <code>Defining Document</code> property of an <a>Entry</a>.</dd>
+          <dd class="note">A more detailed definition is provided in each <a>Metadata Register Structure Document</a>.</dd>
         <dt><dfn>Metadata Register</dfn></dt>
           <dd>Collection of <a>Entry</a>(ies) defined by a <a>Metadata Register Structure Document</a>.</dd>
         <dt><dfn>Metadata Register Structure Document</dfn></dt>
-          <dd>SMPTE Engineering Document that defines a <a>Metadata Register</a>.
-            <p class="note">The SMPTE Registration Authority website lists <a>Metadata Register Structure Document</a>s, as provided by <a href="#sec-structure-documents"></a>.
-          </p>
+          <dd>SMPTE Engineering Document that defines a <a>Metadata Register</a>.</dd>
+          <dd class="note">The SMPTE Registration Authority website lists <a>Metadata Register Structure Document</a>s, as provided by <a href="#sec-structure-documents"></a>.
           </dd>
         <dt><dfn>Release</dfn></dt>
           <dd>A SMPTE Standard, or a revision or amendment thereof, whose elements consists of one or more <a>Metadata Register</a>s to be published.</dd>
@@ -454,7 +451,7 @@
           </p>
         </section>
 
-        <section>
+        <section id="sec-mature-to-withdrawn">
           <h4>Transition to Withdrawn State</h4>
           <p>
             The <a>Submission</a> shall transition to "withdrawn" if:


### PR DESCRIPTION
* A new version of AG 18 was created in https://github.com/SMPTE/ag-18/pull/3 and merged but these changes were later wiped out when the doc was converted to HTML (from an older copy of the Word document). This PR reinstates those changes.
* Move listings of "Private-use/Public-use entries under SMPTE Control" to the Registers Website -- closes https://github.com/SMPTE/ag-18/issues/8
* HTML improvements and corrections
* Use latest version of html-pub