### PR TITLE
Fix normative/informative labelling of annexes after html-pub tooling change

### DIFF
--- a/doc/main.html
+++ b/doc/main.html
@@ -483,7 +483,7 @@
     </section>
 
     <section class="annex" id="sec-acceptance-criteria">
-      <h2>Acceptance Criteria (normative)</h2>
+      <h2>Acceptance Criteria</h2>
 
       <section id="sec-acceptance-general">
         <h3>General</h3>
@@ -777,8 +777,8 @@ REGISTER := "groups" / "elements" / "labels" / "types" / "essence"
       
     </section>
 
-    <section class="annex" id="sec-examples">
-      <h2>Examples (informative)</h2>
+    <section class="annex informative" id="sec-examples">
+      <h2>Examples</h2>
 
       <section id="sec-example-eng-doc-defining">
         <h3>SMPTE Engineering Document as <a>Defining Document</a></h3>
@@ -824,7 +824,7 @@ REGISTER := "groups" / "elements" / "labels" / "types" / "essence"
 
     <section class="annex" id="sec-allocation-transfer">
       <h2>
-        Allocation and Transfer of Control of <a>Public-Use Entry</a>(ies) and <a>Private-Use Entry</a>(ies) (normative)
+        Allocation and Transfer of Control of <a>Public-Use Entry</a>(ies) and <a>Private-Use Entry</a>(ies)
       </h2>
 
       <section id="sec-allocation">
@@ -858,7 +858,7 @@ REGISTER := "groups" / "elements" / "labels" / "types" / "essence"
     </section>
 
     <section class="annex" id="sec-private-use-control">
-      <h2><a>Private-Use Entry</a>(ies) under SMPTE Control (normative)</h2>
+      <h2><a>Private-Use Entry</a>(ies) under SMPTE Control</h2>
       <p>
         The SMPTE Registration Authority website shall include a list of <a>Private-Use Entry</a>(ies) whose control has been delegated to SMPTE.
       </p>
@@ -870,7 +870,7 @@ REGISTER := "groups" / "elements" / "labels" / "types" / "essence"
     </section>
 
     <section class="annex" id="sec-public-use-control">
-      <h2><a>Public-Use Entry</a>(ies) under SMPTE Control (normative)</h2>
+      <h2><a>Public-Use Entry</a>(ies) under SMPTE Control</h2>
       <p>
         The SMPTE Registration Authority website shall include a list of <a>Public-Use Entry</a>(ies) whose control has been delegated to SMPTE.
       </p>


### PR DESCRIPTION
Examples from html rendering of problems caused:

```
Annex A
Acceptance Criteria (normative) (Normative)
```

```
Annex B
Examples (informative) (Normative)
```

FYI @SteveLLamb -- I imagine this has affected other AGs